### PR TITLE
Update webhooks to include `message.bounce_detected`

### DIFF
--- a/lib/nylas/resources/webhooks.rb
+++ b/lib/nylas/resources/webhooks.rb
@@ -22,6 +22,7 @@ module Nylas
     MESSAGE_CREATED = "message.created"
     MESSAGE_UPDATED = "message.updated"
     MESSAGE_OPENED = "message.opened"
+    MESSAGE_BOUNCE_DETECTED = "message.bounce_detected"
     MESSAGE_LINK_CLICKED = "message.link_clicked"
     THREAD_REPLIED = "thread.replied"
     FOLDER_CREATED = "folder.created"


### PR DESCRIPTION
<!-- Your PR comment must contain the following lines for us to merge the PR. -->

# Description
The `message.bounce_detected` seems to be missing and I'm adding it here.
https://developer.nylas.com/docs/v3/notifications/notification-schemas/#message-bounce-detected-notifications
<!-- A clear and concise description of what the PR is introducing/changing. -->

# License
I confirm that this contribution is made under the terms of the MIT license and that I have the authority necessary to make this contribution on behalf of its copyright owner.